### PR TITLE
Add `git clone` OS matrix basic GitHub Actions checks

### DIFF
--- a/.github/workflows/git-clone-matrix.yml
+++ b/.github/workflows/git-clone-matrix.yml
@@ -1,0 +1,27 @@
+name: Git Clone Matrix Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-git-clone:
+    name: 'Test git clone on ${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout the current repo
+        uses: actions/checkout@v4
+
+      - name: Run git clone test
+        run: |
+          git clone https://github.com/brisbanesocialchess/brisbanesocialchess.github.io.git
+          echo "Cloned successfully on ${{ matrix.os }}"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,25 +1,41 @@
-name: Run pre-commit hooks
+name: Run pre-commit
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   pre-commit:
+    name: Run pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Checkout ${{ github.ref }} ( ${{ github.sha }} )
+        uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          architecture: 'x64'
 
       - name: Install dependencies
-        run: pip install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
 
-      - name: Run pre-commit hooks
+      - name: Set PY
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
         run: pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,25 @@
+name: Run pre-commit hooks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files


### PR DESCRIPTION

This PR adds a basic GitHub Actions workflow to test `git clone` across multiple operating systems:

* ✅ Ubuntu
* 🍏 macOS
* 🪟 Windows

This ensures the repository can be cloned and accessed reliably across environments.

Fixes: #18 