### PR TITLE
feat: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Normalize line endings for text files
+* text=auto
+
+# Content and code files
+*.md text
+*.html text
+*.css text
+*.js text
+*.toml text
+*.yaml text
+*.yml text
+
+# Binary files (images, fonts, PDFs)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+
+# Ensure shell scripts use LF line endings
+*.sh text eol=lf
+
+# Exclude documentation files from git archive exports
+README.md export-ignore
+
+# Optionally exclude local configuration files from exports
+*.local export-ignore


### PR DESCRIPTION
# `.gitattributes` File Addition (Issue #27)

## Changes Introduced

- **Line Ending Normalization:**  
  Text files such as Markdown, HTML, CSS, JavaScript, and configuration files (`.toml`, `.yaml`) are configured to automatically normalize line endings. This prevents issues caused by different OSs using different end-of-line characters (LF vs CRLF).

- **Binary File Handling:**  
  Common binary files like images (`.png`, `.jpg`, `.svg`, etc.), fonts, and PDFs are marked as binary. This tells Git not to attempt text diffs or merge operations on these files, which could corrupt them.

- **Shell Script Line Endings:**  
  Shell scripts (`.sh`) are forced to use LF line endings to ensure they run correctly in Unix-like environments.

- **Export Ignore Rules:**  
  Some files, such as the README and local config files, are excluded from export archives generated with `git archive`. This helps keep deployment packages clean.


