### PR TITLE
changed nav link text

### DIFF
--- a/docs/terms.html
+++ b/docs/terms.html
@@ -24,7 +24,7 @@
           <a href="index.html">Home</a>
           <a href="games.html">Games</a>
           <a href="minutes.html">Minutes</a>
-          <a href="register.html">How to Register</a>
+          <a href="register.html">Register</a>
           <a href="rules.html">Rules</a>
           <a href="terms.html" class="active">Terms</a>
         </nav>


### PR DESCRIPTION
- Changed the navigation link text from "How to Register" to "Register"
- This makes the navigation consistent and more concise
Fixes #121 