### PR TITLE
Add pre-commit hook to stop ZIPs being committed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
         entry: |
           Zip files are not allowed in the repository as they are hard to
           track and have security implications. Please remove the zip file from the repository.
-        files: \.zip$
+        files: (?i)\.zip$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v9.31.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,6 @@ repos:
       # - id: pretty-format-json
       - id: check-added-large-files
         args: ['--maxkb=1000']
-
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:
@@ -44,7 +43,6 @@ repos:
       - id: oxipng
         name: oxipng
         args: ['--fix', '-o', '4', '--strip', 'safe', '--alpha']
-
   - repo: local
     hooks:
       - id: npm-ci
@@ -69,7 +67,14 @@ repos:
         entry: npm audit --audit-level=high
         language: system
         pass_filenames: false
-
+      - id: check-zip-file-is-not-committed
+        name: check no zip files are committed
+        description: Zip files are not allowed in the repository
+        language: fail
+        entry: |
+          Zip files are not allowed in the repository as they are hard to
+          track and have security implications. Please remove the zip file from the repository.
+        files: \.zip$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v9.31.0
     hooks:
@@ -77,7 +82,6 @@ repos:
         entry: npm run lint_fix
         language: node
         files: \.(cjs|js|mjs)$
-
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.45.0
     hooks:
@@ -85,7 +89,6 @@ repos:
         name: markdownlint
         types: [markdown]
         args: ['--config', '.github/linters/.markdownlint.json']
-
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.37.1
     hooks:
@@ -95,19 +98,16 @@ repos:
         args: [--strict, -c=.github/linters/.yaml-lint.yml]
         types: [yaml]
         files: \.ya?ml$
-
   # - repo: https://github.com/koalaman/shellcheck-precommit
   #   rev: v0.9.0
   #   hooks:
   #     - id: shellcheck
-
   # - repo: https://github.com/psf/black
   #   rev: 25.1.0
   #   hooks:
   #     - id: black
   #       language_version: python3
   #       args: ["--line-length=88"]
-
   # - repo: https://github.com/PyCQA/bandit
   #   rev: 1.8.6
   #   hooks:


### PR DESCRIPTION
Zip files are not allowed in the repository as they are hard to
          track and have security implications. Please remove the zip file from the repository