### PR TITLE
Fix: center align text in blue buttons on home page

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -126,7 +126,6 @@ ol {
 	flex-direction: column;
 	gap: 0.5rem;
 	margin-top: 1rem;
-	text-align: center;
 }
 
 /* Contact */

--- a/docs/style.css
+++ b/docs/style.css
@@ -126,6 +126,7 @@ ol {
 	flex-direction: column;
 	gap: 0.5rem;
 	margin-top: 1rem;
+	text-align: center;
 }
 
 /* Contact */
@@ -230,6 +231,7 @@ form fieldset input[type='radio'] {
 	border-radius: 30px;
 	border: none;
 	cursor: pointer;
+	text-align: center;
 	transition:
 		background-color 0.3s ease,
 		transform 0.2s ease;


### PR DESCRIPTION
Hi 

I am Sangharsh ,

I fixes the text alignment issue in the blue buttons on the home page.
   
 Changes made:
   - Added `text-align: center` to the `.button` class
   - Added `text-align: center` to the `.button-group` class
   
   This ensures the button text is properly centered both within individual buttons and within the button container.