### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -1,4 +1,6 @@
 name: 🚢 Deploy Workers
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/security/code-scanning/2](https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/security/code-scanning/2)

The fix is to add a `permissions` block to the workflow file `.github/workflows/wrangler.yml`. The best place to add it is at the top level, right after the `name` and before the `on:` block, to set minimal permissions for all jobs in the workflow. Since this workflow only checks out code and deploys using a Cloudflare token, the minimal permission likely required is `contents: read`. If additional permissions are needed (e.g., `actions: read` for certain steps), those can be added, but for most deploy workflows (especially with external tokens/secrets), `contents: read` is sufficient as a starting point.

Edit `.github/workflows/wrangler.yml` as follows:  
- Insert a `permissions:` block at the root of the workflow, just after the `name:` field and before the `on:` block.
- Set `contents: read` as the minimal required permission.

No new imports or further changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
