### PR TITLE
pre-commit prettier check JS files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,6 @@ repos:
         description: format files with prettier
         entry: prettier --config .github/linters/.prettierrc --write
         files: \.(css|js|json|md|ya?ml)$
-        types: [css, javascript, json, markdown, yaml]
         language: node
         additional_dependencies: ['prettier@3.6.2']
       - id: npm-audit


### PR DESCRIPTION
JS files were not being checked so there was a difference when running pre-commit and prettier manually via `npm run format`