### PR TITLE
docs: add coverage instructions in README and update CONTRIBUTING with Python requirements + pre-commit cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ Welcome to **Awesome Social Chess**! We appreciate your interest in contributing
   - [4. ✏️ Make Changes](#4--make-changes)
   - [📐 Formatting & Commit Rules](#-formatting--commit-rules)
     - [🔧 Setting Up dprint](#-setting-up-dprint)
-    - [🧪 Setting Up pre-commit](#%F0%9F%A7%AA-setting-up-pre-commit)
+    - [📦 Installing Python Requirements](#-installing-python-requirements)
+    - [🧪 Setting Up pre-commit](#-setting-up-pre-commit)
   - [5. 📝 Commit Changes](#5--commit-changes)
   - [6. ⬆️ Push Changes](#6--push-changes)
   - [7. 🔄 Create a Pull Request](#7--create-a-pull-request)
@@ -110,15 +111,19 @@ Our configuration is already in the repo: [dprint.json](./dprint.json)
 
 ---
 
+#### 📦 Installing Python Requirements
+
+Some of our tools (like `pre-commit`) require Python dependencies.  
+You can install them from `requirements.txt`:
+
+```bash
+python -m pip install -r requirements.txt
+```
+---
+
 #### 🧪 Setting Up pre-commit
 
 We use [pre-commit](https://pre-commit.com/) to automatically check your code for common issues, like missing end-of-file newlines and inconsistent line endings. This keeps our project clean and easy for everyone to work on.
-
-**How to install (requires Python):**
-
-```bash
-python -m pip install --user pre-commit
-```
 
 **Set up pre-commit hooks for this project:**
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This site is built using [Eleventy (11ty)](https://www.11ty.dev/), a modern and 
   - [⚡ Cloudflare Workers Development](#-cloudflare-workers-development)
     - [▶️ Start Development Server](#-start-development-server)
     - [🏃 Run Tests](#-run-tests)
+    - [📊 Run Coverage Reports](#-run-coverage-reports)
   - [🏗️ Getting Started / Building the Site](#-getting-started--building-the-site)
   - [🐳 Build the Docker image for running `pre-commit` easily](#-build-the-docker-image-for-running-pre-commit-easily)
   - [📚 Build the Documentation](#-build-the-documentation)
@@ -119,6 +120,21 @@ npx wrangler dev
 ```bash
 cd packages/cfsite
 npm run test
+```
+
+#### 📊 Run Coverage Reports
+
+Generates a coverage report showing how much of the codebase is covered by tests.
+
+
+- **Frontend (root):** generates test coverage for the frontend code
+```bash
+npm run coverage
+```
+- Backend (Cloudflare Workers in `packages/cfsite`): generates test coverage for the backend code
+```bash
+cd packages/cfsite
+npm run coverage
 ```
 
 Read below for instructions about the current static development site hosted on [GitHub Pages](https://pages.github.com/).


### PR DESCRIPTION
This PR updates the documentation:

- Adds `npm run coverage` instructions for frontend (root) and backend (`packages/cfsite`) in README.md (#677)
- Adds info on installing Python packages from requirements.txt in CONTRIBUTING.md
- Cleans up pre-commit setup instructions (#628)

Closes #677, Closes #628