### PR TITLE
Fix:  align GitHub Triage avatar to Eddie/Jasper on mobile; adjust wrapper width for consistent scaling

### DIFF
--- a/frontend/about.md
+++ b/frontend/about.md
@@ -172,7 +172,7 @@ title: About Us
 	</h3>
 	<div class="flex flex-wrap justify-center items-end gap-6 mb-8">
 		<a href="https://github.com/michal-duszak" class="flex flex-col items-center text-center team-role team-role-github-triage text-team-role-github-triage">
-			<img class="w-32 md:w-40 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/michal-duszak.jpeg' | url }}" alt="Michal Duszak avatar" />
+			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/michal-duszak.jpeg' | url }}" alt="Michal Duszak avatar" />
 			<span class="font-medium">Michal Duszak</span>
 			<span class="github">@michal-duszak</span>
 		</a>

--- a/frontend/about.md
+++ b/frontend/about.md
@@ -171,7 +171,7 @@ title: About Us
 		<span aria-hidden="true">💿</span> GitHub Triage
 	</h3>
 	<div class="flex flex-wrap justify-center items-end gap-6 mb-8">
-		<a href="https://github.com/michal-duszak" class="flex flex-col items-center text-center team-role team-role-github-triage text-team-role-github-triage">
+		<a href="https://github.com/michal-duszak" class="flex flex-col items-center text-center w-1/3 team-role team-role-github-triage text-team-role-github-triage">
 			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/michal-duszak.jpeg' | url }}" alt="Michal Duszak avatar" />
 			<span class="font-medium">Michal Duszak</span>
 			<span class="github">@michal-duszak</span>


### PR DESCRIPTION
### **What does this PR do?**

Fixes #791
Fixes the responsive image sizing for GitHub Triage on the About page so it matches Eddie/Jasper on mobile and across breakpoints.
Also adjusts the wrapper width so the avatar scaling is consistent when the image alone isn’t enough.


### **Screenshots**
Mobile view:
<img width="241" height="695" alt="image" src="https://github.com/user-attachments/assets/6cc90d27-317d-4b1a-bd47-9af14688e549" />

Desktop view:
<img width="787" height="926" alt="image" src="https://github.com/user-attachments/assets/31a2b6e6-4caa-47ca-ba44-5413f1781595" />


**### What changed**

About page
Updated GitHub Triage image classes to use the same responsive sizes as Eddie/Jasper:
w-20 md:w-28 lg:w-[120px] with aspect-square rounded-full object-cover
Adjusted the surrounding wrapper width to ensure the avatar scales uniformly at small widths.