### PR TITLE
fix: make global moderators section responsive on about page

### DIFF
--- a/DEVELOPER_HELP.md
+++ b/DEVELOPER_HELP.md
@@ -92,21 +92,23 @@ These checks ensure your code follows the project's style guidelines and passes 
 
 ## Development Platforms
 
-[Cloudflare Workers](https://developers.cloudflare.com/workers/) is a serverless platform for building, deploying, and scaling apps across Cloudflare's global network with a single command - no infrastructure to manage, no complex configuration.
-
-[Lerna](https://lerna.js.org/) is a tool for optimizing the workflow around managing multi-package repositories (monorepos).
-
-[Vitest](https://vitest.dev/) is a blazing-fast, next-generation testing framework designed for modern JavaScript and TypeScript projects, built on top of Vite. It's known for its speed and developer experience, offering instant feedback and seamless integration with Vite's features like hot module replacement (HMR). Vitest is inspired by Jest and aims to provide a familiar yet enhanced testing experience.
+## Development Platforms
 
 [Cloudflare Wrangler](https://developers.cloudflare.com/workers/wrangler/) is a command-line tool designed to help developers build and manage applications on the Cloudflare developer platform, particularly for Cloudflare Workers. It streamlines the process of deploying, testing, and configuring Workers, as well as interacting with other Cloudflare developer products.
 
+[Cloudflare Workers](https://developers.cloudflare.com/workers/) is a serverless platform for building, deploying, and scaling apps across Cloudflare's global network with a single command - no infrastructure to manage, no complex configuration.
+
 [GitHub Pages](https://pages.github.com/) is a static site hosting service offered by GitHub, enabling users to host sites directly from their GitHub repositories. It is designed for publishing static content, meaning it primarily handles HTML, CSS, and JavaScript files, and does not support server-side languages like PHP or Python for dynamic content generation.
+
+[Lerna](https://lerna.js.org/) is a tool for optimizing the workflow around managing multi-package repositories (monorepos).
 
 [Read the Docs](https://about.readthedocs.com/) is a Continuous Documentation Deployment platform designed to simplify the process of building, versioning, and hosting technical documentation, particularly for software projects. It operates on the principle of "docs as code," integrating with version control systems like Git (GitHub, GitLab, Bitbucket) to automatically build and update documentation whenever changes are committed to the repository.
 
+[reStructuredText (RST)](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) is a lightweight markup language designed for creating easy-to-read and easy-to-write plaintext documents that can be automatically converted to various output formats, such as HTML, LaTeX (and thus PDF), and more. It is a key component of the Docutils project and is widely used in the Python community for writing technical documentation, including Python's official documentation and documentation for many Python libraries.
+
 [Sphinx](https://www.sphinx-doc.org/en/master/) is a powerful and widely-used documentation generator written in Python. It is particularly popular within the Python community and is considered the de facto standard for documenting Python projects.
 
-[reStructuredText (RST)](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) is a lightweight markup language designed for creating easy-to-read and easy-to-write plaintext documents that can be automatically converted to various output formats, such as HTML, LaTeX (and thus PDF), and more. It is a key component of the Docutils project and is widely used in the Python community for writing technical documentation, including Python's official documentation and documentation for many Python libraries.
+[Vitest](https://vitest.dev/) is a blazing-fast, next-generation testing framework designed for modern JavaScript and TypeScript projects, built on top of Vite. It's known for its speed and developer experience, offering instant feedback and seamless integration with Vite's features like hot module replacement (HMR). Vitest is inspired by Jest and aims to provide a familiar yet enhanced testing experience.
 
 ## Cloudflare Workers Development
 

--- a/DEVELOPER_HELP.md
+++ b/DEVELOPER_HELP.md
@@ -92,8 +92,6 @@ These checks ensure your code follows the project's style guidelines and passes 
 
 ## Development Platforms
 
-## Development Platforms
-
 [Cloudflare Wrangler](https://developers.cloudflare.com/workers/wrangler/) is a command-line tool designed to help developers build and manage applications on the Cloudflare developer platform, particularly for Cloudflare Workers. It streamlines the process of deploying, testing, and configuring Workers, as well as interacting with other Cloudflare developer products.
 
 [Cloudflare Workers](https://developers.cloudflare.com/workers/) is a serverless platform for building, deploying, and scaling apps across Cloudflare's global network with a single command - no infrastructure to manage, no complex configuration.

--- a/frontend/about.md
+++ b/frontend/about.md
@@ -242,40 +242,40 @@ title: About Us
 		</div>
 	</div>
 	<h3 class="text-xl font-semibold mb-4">
-		<span aria-hidden="true">🗺️</span> Global Moderators
-	</h3>
-	<div class="flex flex-wrap justify-center gap-6">
-		<a href="https://github.com/carefreeav09" class="flex flex-col items-center text-center w-1/3 team-role team-role-moderator text-team-role-moderator">
-			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/carefreeav09.jpeg' | url }}" alt="Abhushan Gautam avatar" />
-			<span class="font-medium">Abhushan Gautam</span>
-			<span class="github">@carefreeav09</span>
-		</a>
-		<a href="https://github.com/ayushrana182" class="flex flex-col items-center text-center w-1/3 team-role team-role-moderator text-team-role-moderator">
-			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/ayush.jpeg' | url }}" alt="Ayush Rana avatar" />
-			<span class="font-medium">Ayush Rana</span>
-			<span class="github">@ayushrana182</span>
-		</a>
-		<a href="https://github.com/abdorah" class="flex flex-col items-center text-center w-1/3 team-role team-role-moderator text-team-role-moderator">
-			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/abdorah.jpg' | url }}" alt="Kotbi Abderrahmane avatar" />
-			<span class="font-medium">Kotbi Abderrahmane</span>
-			<span class="github">@abdorah</span>
-		</a>
-		<a href="https://github.com/mohammadlotfia" class="flex flex-col items-center text-center w-1/3 team-role team-role-moderator text-team-role-moderator">
-			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/mohammadlotfia.png' | url }}" alt="Mohammad Lotfi Akbarabadi avatar" />
-			<span class="font-medium">Mohammad Lotfi Akbarabadi</span>
-			<span class="github">@mohammadlotfia</span>
-		</a>
-		<a href="https://github.com/udha" class="flex flex-col items-center text-center w-1/3 team-role team-role-moderator text-team-role-moderator">
-			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/udha.png' | url }}" alt="Nicholas Meredith avatar" />
-			<span class="font-medium">Nicholas Meredith</span>
-			<span class="github">@udha</span>
-		</a>
-		<a href="https://github.com/smriad" class="flex flex-col items-center text-center w-1/3 team-role team-role-moderator text-team-role-moderator">
-			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/smriad.png' | url }}" alt="SM Riad avatar" />
-			<span class="font-medium">SM Riad</span>
-			<span class="github">@smriad</span>
-		</a>
-	</div>
+	<span aria-hidden="true">🗺️</span> Global Moderators
+</h3>
+<div class="flex flex-wrap justify-center gap-6">
+	<a href="https://github.com/carefreeav09" class="flex flex-col items-center text-center w-full sm:w-1/2 md:w-1/3 team-role team-role-moderator text-team-role-moderator">
+		<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/carefreeav09.jpeg' | url }}" alt="Abhushan Gautam avatar" />
+		<span class="font-medium">Abhushan Gautam</span>
+		<span class="github">@carefreeav09</span>
+	</a>
+	<a href="https://github.com/ayushrana182" class="flex flex-col items-center text-center w-full sm:w-1/2 md:w-1/3 team-role team-role-moderator text-team-role-moderator">
+		<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/ayush.jpeg' | url }}" alt="Ayush Rana avatar" />
+		<span class="font-medium">Ayush Rana</span>
+		<span class="github">@ayushrana182</span>
+	</a>
+	<a href="https://github.com/abdorah" class="flex flex-col items-center text-center w-full sm:w-1/2 md:w-1/3 team-role team-role-moderator text-team-role-moderator">
+		<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/abdorah.jpg' | url }}" alt="Kotbi Abderrahmane avatar" />
+		<span class="font-medium">Kotbi Abderrahmane</span>
+		<span class="github">@abdorah</span>
+	</a>
+	<a href="https://github.com/mohammadlotfia" class="flex flex-col items-center text-center w-full sm:w-1/2 md:w-1/3 team-role team-role-moderator text-team-role-moderator">
+		<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/mohammadlotfia.png' | url }}" alt="Mohammad Lotfi Akbarabadi avatar" />
+		<span class="font-medium">Mohammad Lotfi Akbarabadi</span>
+		<span class="github">@mohammadlotfia</span>
+	</a>
+	<a href="https://github.com/udha" class="flex flex-col items-center text-center w-full sm:w-1/2 md:w-1/3 team-role team-role-moderator text-team-role-moderator">
+		<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/udha.png' | url }}" alt="Nicholas Meredith avatar" />
+		<span class="font-medium">Nicholas Meredith</span>
+		<span class="github">@udha</span>
+	</a>
+	<a href="https://github.com/smriad" class="flex flex-col items-center text-center w-full sm:w-1/2 md:w-1/3 team-role team-role-moderator text-team-role-moderator">
+		<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/smriad.png' | url }}" alt="SM Riad avatar" />
+		<span class="font-medium">SM Riad</span>
+		<span class="github">@smriad</span>
+	</a>
+</div>
 </section>
 
 <section class="px-4 max-w-3xl">


### PR DESCRIPTION
Change made: Replaced w-1/3 with w-full sm:w-1/2 md:w-1/3 on all moderator cards.
This makes the layout:

Mobile (< 640px): 1 column (100% width)
Tablet (≥ 640px): 2 columns (50% width each)
Desktop (≥ 768px): 3 columns (33.33% width each)