### PR TITLE
Refactored the Brisbane Moderators section to use CSS Grid layout instead of   duplicate flex containers.

### DIFF
--- a/frontend/about.md
+++ b/frontend/about.md
@@ -223,20 +223,18 @@ title: About Us
 	<h3 class="text-xl font-semibold mb-4">
 		<span aria-hidden="true">🇦🇺</span> Brisbane Moderators
 	</h3>
-	<div class="flex flex-wrap justify-center gap-6">
+	<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 justify-items-center">
 		<a href="https://github.com/therealnugget" class="flex flex-col items-center text-center team-role team-role-coordinator text-team-role-coordinator">
 			<img class="w-32 md:w-40 lg:w-[225px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/therealnugget.jpeg' | url }}" alt="therealnugget avatar" />
 			<span class="font-medium">Thomas</span>
 			<span class="github">@therealnugget</span>
 		</a>
-	</div>
-	<div class="flex flex-wrap justify-center gap-6">
-		<div class="flex flex-col items-center text-center w-1/3 team-role team-role-leader text-team-role-leader">
+		<div class="flex flex-col items-center text-center team-role team-role-leader text-team-role-leader">
 			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/octocat.png' | url }}" alt="Eddie avatar" />
 			<span class="font-medium">Eddie</span>
 			<span class="github">N/A</span>
 		</div>
-		<div class="flex flex-col items-center text-center w-1/3 team-role team-role-leader text-team-role-leader">
+		<div class="flex flex-col items-center text-center team-role team-role-leader text-team-role-leader">
 			<img class="w-20 md:w-28 lg:w-[120px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/octocat.png' | url }}" alt="Jasper avatar" />
 			<span class="font-medium">Jasper</span>
 			<span class="github">N/A</span>


### PR DESCRIPTION
- Replaced two separate `<div class="flex flex-wrap justify-center gap-6">` containers with a single grid container
- Implemented CSS Grid layout: `grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3
  gap-6 justify-items-center`

resolves #739 