### PR TITLE
fix: match Thomas avatar size to Max Base on about page

### DIFF
--- a/frontend/about.md
+++ b/frontend/about.md
@@ -172,7 +172,7 @@ title: About Us
 	</h3>
 	<div class="flex flex-wrap justify-center items-start md:items-end gap-6 mb-8">
 		<a href="https://github.com/BaseMax" class="flex flex-col items-center text-center team-role team-role-lead-developer text-team-role-lead-developer">
-			<img class="w-35 md:w-50 lg:w-[300px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/basemax.jpeg' | url }}" alt="Max Base avatar" />
+			<img class="w-32 md:w-48 lg:w-[300px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/basemax.jpeg' | url }}" alt="Max Base avatar" />
 			<span class="font-medium">Max Base</span>
 			<span class="github">@BaseMax</span>
 		</a>
@@ -225,7 +225,7 @@ title: About Us
 	</h3>
 	<div class="flex flex-wrap justify-center gap-6">
 		<a href="https://github.com/therealnugget" class="flex flex-col items-center text-center team-role team-role-coordinator text-team-role-coordinator">
-			<img class="w-35 md:w-50 lg:w-[300px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/therealnugget.jpeg' | url }}" alt="therealnugget avatar" />
+			<img class="w-32 md:w-48 lg:w-[300px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/therealnugget.jpeg' | url }}" alt="therealnugget avatar" />
 			<span class="font-medium">Thomas</span>
 			<span class="github">@therealnugget</span>
 		</a>

--- a/frontend/about.md
+++ b/frontend/about.md
@@ -225,7 +225,7 @@ title: About Us
 	</h3>
 	<div class="flex flex-wrap justify-center gap-6">
 		<a href="https://github.com/therealnugget" class="flex flex-col items-center text-center team-role team-role-coordinator text-team-role-coordinator">
-			<img class="w-32 md:w-40 lg:w-[225px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/therealnugget.jpeg' | url }}" alt="therealnugget avatar" />
+			<img class="w-35 md:w-50 lg:w-[300px] aspect-square rounded-full object-cover mb-2" src="{{ '/assets/avatars/therealnugget.jpeg' | url }}" alt="therealnugget avatar" />
 			<span class="font-medium">Thomas</span>
 			<span class="github">@therealnugget</span>
 		</a>


### PR DESCRIPTION
The change: Replace w-32 md:w-40 lg:w-[225px] with w-35 md:w-50 lg:w-[300px] to match Max Base's avatar dimensions exactly.