### PR TITLE
Remove caching from ViteImageOptimizer

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -38,7 +38,6 @@ export default defineConfig({
 		ViteImageOptimizer({
 			ansiColors: true,
 			avif: { lossless: true },
-			cache: true,
 			gif: {},
 			includePublic: true,
 			jpeg: { quality: 80 },


### PR DESCRIPTION
The object is to remove the duplication of image folder named assets.

closes #707