### PR TITLE
[CI:security]: Dependabot add a cooldown period for new releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
       github-dependencies:
         patterns:
           - '*'
-
+    cooldown:
+      default-days: 7
+  
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -17,6 +19,8 @@ updates:
       npm-dependencies:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'pip'
     directory: '/'
@@ -26,3 +30,5 @@ updates:
       python-dependencies:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Enforces security best practices by requiring a minimum age for new dependency releases before they are automatically updated by Dependabot.

This practice, known as a "cooldown period," helps mitigate supply chain attacks by allowing time for frequently published malicious packages to be identified.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-
