### PR TITLE
Fix 954 codespell migration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,0 @@
-[codespell]
-ignore-words = .github/linters/codespell.txt
-skip = package-lock.json,yarn.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
       - id: codespell
         name: Run codespell
         description: Check spelling with codespell
+        args: ['--toml', 'pyproject.toml']
+        additional_dependencies: ['tomli']
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6
     hooks:

--- a/.pre-commit-docker-config.yaml
+++ b/.pre-commit-docker-config.yaml
@@ -1,0 +1,11 @@
+---
+# https://pre-commit.com/#installation
+default_stages: [pre-commit, pre-push]
+minimum_pre_commit_version: '3.2.0'
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker
+        name: Lint Dockerfiles
+        description: Runs hadolint Docker image to lint Dockerfiles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,7 @@ subprocess = [
   "subprocess.check_call",
   "subprocess.check_output",
 ]
+
+[tool.codespell]
+ignore-words = ".github/linters/codespell.txt"
+skip = "package-lock.json,yarn.lock"


### PR DESCRIPTION
Migrates `codespell` configuration to [pyproject.toml](cci:7://file:///Users/subhamsangwan/brisbanesocialchess.github.io/pyproject.toml:0:0-0:0).

Fixes #954

# Pull Request

## PR Checklist
- [x] Tested locally.
- [x] Ran `pre-commit run --all-files`.
- [x] Reviewed for potential issues.

## PR Type
- [x] Refactor

## Summary
Moved `codespell` settings from [.codespellrc](cci:7://file:///Users/subhamsangwan/brisbanesocialchess.github.io/.codespellrc:0:0-0:0) to the `[tool.codespell]` section in `pyproject.toml`. The legacy configuration file has been removed. Verified locally that all file exclusions are respected.
